### PR TITLE
Advanced Sorting Feature implemented

### DIFF
--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -12,7 +12,7 @@ import javafx.application.Application;
  *
  * The reason is that MainApp extends Application. In that case, the
  * LauncherHelper will check for the javafx.graphics module to be present
- * as a named module. We don't use JavaFX via the module system so it can't
+ * as a named module. We don't use JavaFX via the module system, so it can't
  * find the javafx.graphics module, and so the launch is aborted.
  *
  * By having a separate main class (Main) that doesn't extend Application

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -78,7 +78,7 @@ public class MainApp extends Application {
         ReadOnlyAddressBook initialData;
         try {
             addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
+            if (addressBookOptional.isEmpty()) {
                 logger.info("Data file not found. Will be starting with a sample AddressBook");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -8,9 +8,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
+import seedu.address.model.tag.Tag;
 
 /**
  * Sorts the address book.
@@ -21,49 +24,90 @@ public class SortCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Sort the list of contacts displayed by certain parameter(s).\n"
+        + "Insert a ! after a / to sort in reverse.\n"
+        + "Sort with multiple parameters, succeeding parameters will be used as tiebreakers "
+        + "when sorting with preceding parameters.\n"
         + "Parameters: "
         + "[" + PREFIX_NAME + "] "
         + "[" + PREFIX_PHONE + "] "
         + "[" + PREFIX_EMAIL + "] "
         + "[" + PREFIX_ADDRESS + "] "
         + "[" + PREFIX_TAG + "TAG]...\n"
-        + "Example: " + COMMAND_WORD + " " + PREFIX_NAME;
+        + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "!friend";
 
-    public static final String MESSAGE_SUCCESS = "List has been sorted by: ";
-    public static final String MESSAGE_WRONG_PREFIX = "Invalid parameter";
+    public static final String MESSAGE_SUCCESS = "List has been sorted.";
+    public static final String MESSAGE_WRONG_PREFIX = "Invalid parameter(s)";
 
-    private final Prefix parameter;
-    private final Boolean isReverse;
+    private final List<SortArgument> argList;
 
     /**
      * Creates a SortCommand to sort the address book.
      */
-    public SortCommand(Prefix prefix, Boolean isReverse) {
-        requireAllNonNull(prefix, isReverse);
-        this.parameter = prefix;
-        this.isReverse = isReverse;
+    public SortCommand(List<SortArgument> argList) {
+        requireAllNonNull(argList);
+        this.argList = argList;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (parameter.equals(PREFIX_NAME)) {
-            model.sortByName();
-        } else if (parameter.equals(PREFIX_PHONE)) {
-            model.sortByPhone();
-        } else if (parameter.equals(PREFIX_EMAIL)) {
-            model.sortByEmail();
-        } else if (parameter.equals(PREFIX_ADDRESS)) {
-            model.sortByAddress();
-        } else {
-            throw new CommandException(MESSAGE_WRONG_PREFIX);
+        // Start sorting from the last argument. Each sort is stable, preserving the previous order.
+        for (int i = argList.size() - 1; i >= 0; i--) {
+            SortArgument currSort = argList.get(i);
+            Prefix prefixParam = currSort.getPrefix();
+            boolean isReverse = currSort.getIsReverse();
+
+            if (prefixParam.equals(PREFIX_NAME)) {
+                model.sortByName(isReverse);
+            } else if (prefixParam.equals(PREFIX_PHONE)) {
+                model.sortByPhone(isReverse);
+            } else if (prefixParam.equals(PREFIX_EMAIL)) {
+                model.sortByEmail(isReverse);
+            } else if (prefixParam.equals(PREFIX_ADDRESS)) {
+                model.sortByAddress(isReverse);
+            } else if (prefixParam.equals(PREFIX_TAG)) {
+                model.sortByTag(currSort.getTag(), isReverse);
+            } else {
+                throw new CommandException(MESSAGE_WRONG_PREFIX);
+            }
         }
 
-        if (isReverse) {
-            model.reverseSort();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    /**
+     * Represents an argument for a SortCommand.
+     * Consists of a prefix, whether the sort is reversed, and a tag if the prefix is PREFIX_TAG.
+     */
+    public static class SortArgument {
+        private final Prefix prefix;
+        private final boolean isReverse;
+        private final Tag tag;
+
+        /**
+         * Constructs a SortArgument.
+         *
+         * @param prefix    The prefix to use as the parameter
+         * @param isReverse Whether the sorting order should be reversed
+         * @param tag       The tag to sort with, if the prefix is PREFIX_TAG
+         */
+        public SortArgument(Prefix prefix, boolean isReverse, Tag tag) {
+            this.prefix = prefix;
+            this.isReverse = isReverse;
+            this.tag = tag;
         }
 
-        return new CommandResult(MESSAGE_SUCCESS + parameter.getPrefix());
+        public Prefix getPrefix() {
+            return prefix;
+        }
+
+        public boolean getIsReverse() {
+            return isReverse;
+        }
+
+        public Tag getTag() {
+            return tag;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -140,8 +140,11 @@ public class SortCommand extends Command {
                 return false;
             }
             SortArgument otherSort = (SortArgument) other;
-            if (tag == null) {
-                return otherSort.tag == null;
+            if (tag == null && otherSort.tag != null) {
+                return false;
+            }
+            if (tag == otherSort.tag) {
+                return isReverse == otherSort.isReverse && prefix.equals(otherSort.prefix);
             }
             return isReverse == otherSort.isReverse && prefix.equals(otherSort.prefix) && tag.equals(otherSort.tag);
         }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -76,6 +76,27 @@ public class SortCommand extends Command {
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof SortCommand)) {
+            return false;
+        }
+        if (argList.size() != ((SortCommand) other).argList.size()) {
+            return false;
+        }
+        boolean result = true;
+        for (int i = 0; i < argList.size(); i++) {
+            result = argList.get(i).equals(((SortCommand) other).argList.get(i));
+            if (result == false) {
+                break;
+            }
+        }
+        return result;
+    }
+
     /**
      * Represents an argument for a SortCommand.
      * Consists of a prefix, whether the sort is reversed, and a tag if the prefix is PREFIX_TAG.
@@ -108,6 +129,21 @@ public class SortCommand extends Command {
 
         public Tag getTag() {
             return tag;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof SortArgument)) {
+                return false;
+            }
+            SortArgument otherSort = (SortArgument) other;
+            if (tag == null) {
+                return otherSort.tag == null;
+            }
+            return isReverse == otherSort.isReverse && prefix.equals(otherSort.prefix) && tag.equals(otherSort.tag);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -36,7 +36,7 @@ public class SortCommand extends Command {
         + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "!friend";
 
     public static final String MESSAGE_SUCCESS = "List has been sorted.";
-    public static final String MESSAGE_WRONG_PREFIX = "Invalid parameter(s)";
+    public static final String MESSAGE_WRONG_PREFIX = "Invalid parameter(s).";
 
     private final List<SortArgument> argList;
 
@@ -56,7 +56,7 @@ public class SortCommand extends Command {
         for (int i = argList.size() - 1; i >= 0; i--) {
             SortArgument currSort = argList.get(i);
             Prefix prefixParam = currSort.getPrefix();
-            boolean isReverse = currSort.getIsReverse();
+            boolean isReverse = currSort.isReverse();
 
             if (prefixParam.equals(PREFIX_NAME)) {
                 model.sortByName(isReverse);
@@ -103,19 +103,19 @@ public class SortCommand extends Command {
      */
     public static class SortArgument {
         private final Prefix prefix;
-        private final boolean isReverse;
+        private final boolean isSortingReversed;
         private final Tag tag;
 
         /**
          * Constructs a SortArgument.
          *
-         * @param prefix    The prefix to use as the parameter
-         * @param isReverse Whether the sorting order should be reversed
-         * @param tag       The tag to sort with, if the prefix is PREFIX_TAG
+         * @param prefix            The prefix to use as the parameter
+         * @param isSortingReversed Whether the sorting order should be reversed
+         * @param tag               The tag to sort with, if the prefix is PREFIX_TAG
          */
-        public SortArgument(Prefix prefix, boolean isReverse, Tag tag) {
+        public SortArgument(Prefix prefix, boolean isSortingReversed, Tag tag) {
             this.prefix = prefix;
-            this.isReverse = isReverse;
+            this.isSortingReversed = isSortingReversed;
             this.tag = tag;
         }
 
@@ -123,8 +123,8 @@ public class SortCommand extends Command {
             return prefix;
         }
 
-        public boolean getIsReverse() {
-            return isReverse;
+        public boolean isReverse() {
+            return isSortingReversed;
         }
 
         public Tag getTag() {
@@ -144,9 +144,11 @@ public class SortCommand extends Command {
                 return false;
             }
             if (tag == otherSort.tag) {
-                return isReverse == otherSort.isReverse && prefix.equals(otherSort.prefix);
+                return isSortingReversed == otherSort.isSortingReversed && prefix.equals(otherSort.prefix);
             }
-            return isReverse == otherSort.isReverse && prefix.equals(otherSort.prefix) && tag.equals(otherSort.tag);
+            return isSortingReversed == otherSort.isSortingReversed
+                && prefix.equals(otherSort.prefix)
+                && tag.equals(otherSort.tag);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,9 +1,21 @@
 package seedu.address.logic.parser;
 
-import java.util.stream.Stream;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.ArgumentTokenizer.PrefixArgument;
+import static seedu.address.logic.parser.ArgumentTokenizer.tokenizeToList;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortArgument;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new SortCommand object
@@ -12,20 +24,51 @@ public class SortCommandParser implements Parser<SortCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
      * and returns an SortCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public SortCommand parse(String args) throws ParseException {
-        Boolean isReverse = args.trim().charAt(0) == '!';
+        List<PrefixArgument> argList =
+            tokenizeToList(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        boolean hasArguments = argList.size() != 1;
 
-        Prefix parameter = isReverse ? new Prefix(args.trim().substring(1)) : new Prefix(args.trim());
-        return new SortCommand(parameter, isReverse);
+        if (!hasArguments) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        List<SortArgument> sortArgs = convertPrefixArgToSortArg(argList);
+        return new SortCommand(sortArgs);
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
+     * Convert a list of PrefixArgument to a list of SortArgument.
+     * First dummy PrefixArgument in the list, which represents the preamble, is excluded.
+     *
+     * @param argList List of PrefixArgument
+     * @return        List of SortArgument
      */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    private List<SortArgument> convertPrefixArgToSortArg(List<PrefixArgument> argList) {
+        return argList.subList(1, argList.size()).stream().map(this::convertArguments).collect(Collectors.toList());
+    }
+
+    /**
+     * Convert a PrefixArgument to a SortArgument.
+     *
+     * @param prefixArg PrefixArgument to convert
+     * @return          SortArgument
+     */
+    private SortArgument convertArguments(PrefixArgument prefixArg) {
+        Prefix prefix = prefixArg.getPrefix();
+        String arg = prefixArg.getArgument();
+
+        // Sorting is reversed if the prefix is followed by a '!'
+        boolean isReverse = !arg.isEmpty() && arg.charAt(0) == '!';
+
+        if (prefix.equals(PREFIX_TAG)) {
+            Tag tag = isReverse ? new Tag(arg.substring(1)) : new Tag(arg);
+            return new SortArgument(prefix, isReverse, tag);
+        } else {
+            return new SortArgument(prefix, isReverse, null);
+        }
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -68,24 +68,53 @@ public class AddressBook implements ReadOnlyAddressBook {
         setTags(newData.getTagList());
     }
 
-    public void sortByName() {
-        persons.sortByName();
+    /// sorting operations
+
+    /**
+     * Sorts the address book by name in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
+     */
+    public void sortByName(Boolean isReverse) {
+        persons.sortByName(isReverse);
     }
 
-    public void sortByPhone() {
-        persons.sortByPhone();
+    /**
+     * Sorts the address book by phone number in increasing order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
+     */
+    public void sortByPhone(Boolean isReverse) {
+        persons.sortByPhone(isReverse);
     }
 
-    public void sortByEmail() {
-        persons.sortByEmail();
+    /**
+     * Sorts the address book by email in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
+     */
+    public void sortByEmail(Boolean isReverse) {
+        persons.sortByEmail(isReverse);
     }
 
-    public void sortByAddress() {
-        persons.sortByAddress();
+    /**
+     * Sorts the address book by address in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
+     */
+    public void sortByAddress(Boolean isReverse) {
+        persons.sortByAddress(isReverse);
     }
 
-    public void reverseSort() {
-        persons.reverseSort();
+    /**
+     * Sorts the address book by a tag.
+     * Contacts with the tag appear before those without the tag.
+     *
+     * @param tag       The tag to sort with
+     * @param isReverse Whether the sorting should be in reverse order
+     */
+    public void sortByTag(Tag tag, Boolean isReverse) {
+        persons.sortByTag(tag, isReverse);
     }
 
     //// person-level operations

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,14 +16,14 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
-     * Replaces user prefs data with the data in {@code userPrefs}.
-     */
-    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
-
-    /**
      * Returns the user prefs.
      */
     ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
 
     /**
      * Returns the user prefs' GUI settings.
@@ -45,13 +45,13 @@ public interface Model {
      */
     void setAddressBookFilePath(Path addressBookFilePath);
 
+    /** Returns the AddressBook */
+    ReadOnlyAddressBook getAddressBook();
+
     /**
      * Replaces address book data with the data in {@code addressBook}.
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
-
-    /** Returns the AddressBook */
-    ReadOnlyAddressBook getAddressBook();
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
@@ -79,28 +79,40 @@ public interface Model {
 
     /**
      * Sorts the address book by name in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    void sortByName();
+    void sortByName(Boolean isReverse);
 
     /**
      * Sorts the address book by phone number in increasing order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    void sortByPhone();
+    void sortByPhone(Boolean isReverse);
 
     /**
      * Sorts the address book by email in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    void sortByEmail();
+    void sortByEmail(Boolean isReverse);
 
     /**
      * Sorts the address book by address in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    void sortByAddress();
+    void sortByAddress(Boolean isReverse);
 
     /**
-     * Sorts the address book in reverse order.
+     * Sorts the address book by a tag.
+     * Contacts with the tag appear before those without the tag.
+     *
+     * @param tag       The tag to sort with
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    void reverseSort();
+    void sortByTag(Tag tag, Boolean isReverse);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -46,14 +46,14 @@ public class ModelManager implements Model {
     //=========== UserPrefs ==================================================================================
 
     @Override
-    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        requireNonNull(userPrefs);
-        this.userPrefs.resetData(userPrefs);
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
     }
 
     @Override
-    public ReadOnlyUserPrefs getUserPrefs() {
-        return userPrefs;
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
     }
 
     @Override
@@ -81,13 +81,13 @@ public class ModelManager implements Model {
     //=========== AddressBook ================================================================================
 
     @Override
-    public void setAddressBook(ReadOnlyAddressBook addressBook) {
-        this.addressBook.resetData(addressBook);
+    public ReadOnlyAddressBook getAddressBook() {
+        return addressBook;
     }
 
     @Override
-    public ReadOnlyAddressBook getAddressBook() {
-        return addressBook;
+    public void setAddressBook(ReadOnlyAddressBook addressBook) {
+        this.addressBook.resetData(addressBook);
     }
 
     @Override
@@ -131,28 +131,28 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void sortByName() {
-        addressBook.sortByName();
+    public void sortByName(Boolean isReverse) {
+        addressBook.sortByName(isReverse);
     }
 
     @Override
-    public void sortByPhone() {
-        addressBook.sortByPhone();
+    public void sortByPhone(Boolean isReverse) {
+        addressBook.sortByPhone(isReverse);
     }
 
     @Override
-    public void sortByEmail() {
-        addressBook.sortByEmail();
+    public void sortByEmail(Boolean isReverse) {
+        addressBook.sortByEmail(isReverse);
     }
 
     @Override
-    public void sortByAddress() {
-        addressBook.sortByAddress();
+    public void sortByAddress(Boolean isReverse) {
+        addressBook.sortByAddress(isReverse);
     }
 
     @Override
-    public void reverseSort() {
-        addressBook.reverseSort();
+    public void sortByTag(Tag tag, Boolean isReverse) {
+        addressBook.sortByTag(tag, isReverse);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -42,6 +42,12 @@ public class Address {
         return value;
     }
 
+    /**
+     * Compares this Address to another Address.
+     *
+     * @param other The other Address object
+     * @return      -1 if this object is lesser, 0 if they are equal, 1 otherwise
+     */
     public int compareTo(Address other) {
         return value.compareToIgnoreCase(other.value);
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -56,6 +56,12 @@ public class Email {
         return value;
     }
 
+    /**
+     * Compares this Email to another Email.
+     *
+     * @param other The other Email object
+     * @return      -1 if this object is lesser, 0 if they are equal, 1 otherwise
+     */
     public int compareTo(Email other) {
         return value.compareToIgnoreCase(other.value);
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -44,6 +44,12 @@ public class Name {
         return fullName;
     }
 
+    /**
+     * Compares this Name to another Name.
+     *
+     * @param other The other Name object
+     * @return      -1 if this object is lesser, 0 if they are equal, 1 otherwise
+     */
     public int compareTo(Name other) {
         return fullName.compareToIgnoreCase(other.fullName);
     }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -38,6 +38,12 @@ public class Phone {
         return value;
     }
 
+    /**
+     * Compares this Phone to another Phone.
+     *
+     * @param other The other Phone object
+     * @return      negative integer if this object is lesser, 0 if they are equal, positive integer otherwise
+     */
     public int compareTo(Phone other) {
         return Integer.parseInt(value) - Integer.parseInt(other.value);
     }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -11,13 +11,13 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.tag.Tag;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
  * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
- * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
- * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
- * as to ensure that the person with exactly the same fields will be removed.
+ * persons uses Person#isSamePerson(Person) for equality to ensure that the person being added or updated is
+ * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) to ensure that the person with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
  *
@@ -99,42 +99,88 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Sorts the list by name, alphabetically.
+     * Sorts the address book by name in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    public void sortByName() {
-        SortedList<Person> sorted = internalList.sorted((curr, next) -> curr.getName().compareTo(next.getName()));
+    public void sortByName(Boolean isReverse) {
+        SortedList<Person> sorted;
+        if (!isReverse) {
+            sorted = internalList.sorted((curr, next) -> curr.getName().compareTo(next.getName()));
+        } else {
+            sorted = internalList.sorted((curr, next) -> -1 * (curr.getName().compareTo(next.getName())));
+        }
         internalList.setAll(sorted);
     }
 
     /**
-     * Sorts the list by phone number, in increasing order.
+     * Sorts the address book by phone number in increasing order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    public void sortByPhone() {
-        SortedList<Person> sorted = internalList.sorted((curr, next) -> curr.getPhone().compareTo(next.getPhone()));
+    public void sortByPhone(Boolean isReverse) {
+        SortedList<Person> sorted;
+        if (!isReverse) {
+            sorted = internalList.sorted((curr, next) -> curr.getPhone().compareTo(next.getPhone()));
+        } else {
+            sorted = internalList.sorted((curr, next) -> -1 * (curr.getPhone().compareTo(next.getPhone())));
+        }
         internalList.setAll(sorted);
     }
 
     /**
-     * Sorts the list by email, alphabetically.
+     * Sorts the address book by email in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    public void sortByEmail() {
-        SortedList<Person> sorted = internalList.sorted((curr, next) -> curr.getEmail().compareTo(next.getEmail()));
+    public void sortByEmail(Boolean isReverse) {
+        SortedList<Person> sorted;
+        if (!isReverse) {
+            sorted = internalList.sorted((curr, next) -> curr.getEmail().compareTo(next.getEmail()));
+        } else {
+            sorted = internalList.sorted((curr, next) -> -1 * (curr.getEmail().compareTo(next.getEmail())));
+        }
         internalList.setAll(sorted);
     }
 
     /**
-     * Sorts the list by address, alphabetically.
+     * Sorts the address book by address in alphabetical order.
+     *
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    public void sortByAddress() {
-        SortedList<Person> sorted = internalList.sorted((curr, next) -> curr.getAddress().compareTo(next.getAddress()));
+    public void sortByAddress(Boolean isReverse) {
+        SortedList<Person> sorted;
+        if (!isReverse) {
+            sorted = internalList.sorted((curr, next) -> curr.getAddress().compareTo(next.getAddress()));
+        } else {
+            sorted = internalList.sorted((curr, next) -> -1 * (curr.getAddress().compareTo(next.getAddress())));
+        }
         internalList.setAll(sorted);
     }
 
     /**
-     * Sorts the list in reverse order.
+     * Sorts the address book by a tag.
+     * Contacts with the tag appear before those without the tag.
+     *
+     * @param tag       The tag to sort with
+     * @param isReverse Whether the sorting should be in reverse order
      */
-    public void reverseSort() {
-        FXCollections.reverse(internalList);
+    public void sortByTag(Tag tag, Boolean isReverse) {
+        SortedList<Person> sorted;
+        int flipIfReversed = isReverse ? -1 : 1;
+
+        sorted = internalList.sorted((curr, next) -> {
+            boolean currContains = curr.getTags().contains(tag);
+            boolean nextContains = next.getTags().contains(tag);
+            if (currContains && !nextContains) {
+                return -1 * flipIfReversed;
+            } else if (!currContains && nextContains) {
+                return 1 * flipIfReversed;
+            } else {
+                return 0;
+            }
+        });
+        internalList.setAll(sorted);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -17,7 +17,8 @@ import seedu.address.model.tag.Tag;
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
  * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
  * persons uses Person#isSamePerson(Person) for equality to ensure that the person being added or updated is
- * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) to ensure that the person with exactly the same fields will be removed.
+ * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) to
+ * ensure that the person with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
  *

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -47,8 +47,8 @@ public class UniqueTagList implements Iterable<Tag> {
      * @return True if the tag exists. False if otherwise.
      */
     public boolean hasTag(Tag tag) {
-        for (int i = 0; i < tagArrayList.size(); i++) {
-            if (tagArrayList.get(i).equals(tag)) {
+        for (Tag value : tagArrayList) {
+            if (value.equals(tag)) {
                 return true;
             }
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -140,27 +140,27 @@ public class AddCommandTest {
         }
 
         @Override
-        public void sortByName() {
+        public void sortByName(Boolean isReverse) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void sortByPhone() {
+        public void sortByPhone(Boolean isReverse) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void sortByEmail() {
+        public void sortByEmail(Boolean isReverse) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void sortByAddress() {
+        public void sortByAddress(Boolean isReverse) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void reverseSort() {
+        public void sortByTag(Tag tag, Boolean isReverse) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 class SortCommandTest {

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class SortCommandTest {
+
+    @Test
+    void execute() {
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -38,7 +40,7 @@ class SortCommandTest {
 
     @Test
     void execute_success() throws CommandException {
-        SortCommand sortCommand = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
+        SortCommand sortCommand = new SortCommand(List.of(new SortArgument(PREFIX_NAME, false, null)));
         Model modelStub = new ModelStubThatSorts();
 
         assertEquals(SortCommand.MESSAGE_SUCCESS, sortCommand.execute(modelStub).getFeedbackToUser());
@@ -46,12 +48,12 @@ class SortCommandTest {
 
     @Test
     void testEquals() {
-        SortCommand sampleA = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
-        SortCommand sampleB = new SortCommand(List.of(new SortArgument(new Prefix("a/"), false, null)));
+        SortCommand sampleA = new SortCommand(List.of(new SortArgument(PREFIX_NAME, false, null)));
+        SortCommand sampleB = new SortCommand(List.of(new SortArgument(PREFIX_ADDRESS, false, null)));
         SortCommand sampleC = new SortCommand(List.of(
-            new SortArgument(new Prefix("n/"), false, null),
-            new SortArgument(new Prefix("n/"), false, null)));
-        SortCommand sampleD = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
+            new SortArgument(PREFIX_NAME, false, null),
+            new SortArgument(PREFIX_ADDRESS, false, null)));
+        SortCommand sampleD = new SortCommand(List.of(new SortArgument(PREFIX_NAME, false, null)));
 
         assertEquals(sampleA, sampleA); // same object
         assertNotEquals(1, sampleA); // not SortCommand

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,14 +1,202 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.SortCommand.SortArgument;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 class SortCommandTest {
 
     @Test
-    void execute() {
+    public void constructor_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new SortCommand(null));
+    }
+
+    @Test
+    public void execute_wrongPrefix_throwsCommandException() {
+        SortCommand sortCommand = new SortCommand(List.of(new SortArgument(new Prefix("x/"), false, null)));
+        Model modelStub = new ModelStub();
+
+        assertThrows(CommandException.class, SortCommand.MESSAGE_WRONG_PREFIX, () -> sortCommand.execute(modelStub));
+    }
+
+    @Test
+    void execute_success() throws CommandException {
+        SortCommand sortCommand = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
+        Model modelStub = new ModelStubThatSorts();
+
+        assertEquals(SortCommand.MESSAGE_SUCCESS, sortCommand.execute(modelStub).getFeedbackToUser());
+    }
+
+    @Test
+    void testEquals() {
+        SortCommand sampleA = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
+        SortCommand sampleB = new SortCommand(List.of(new SortArgument(new Prefix("a/"), false, null)));
+        SortCommand sampleC = new SortCommand(List.of(
+            new SortArgument(new Prefix("n/"), false, null),
+            new SortArgument(new Prefix("n/"), false, null)));
+        SortCommand sampleD = new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null)));
+
+        assertEquals(sampleA, sampleA); // same object
+        assertNotEquals(1, sampleA); // not SortCommand
+        assertNotEquals(sampleA, sampleC); // argList of different lengths
+        assertNotEquals(sampleA, sampleB); // different value
+        assertEquals(sampleA, sampleD); // same value
+    }
+
+    /**
+     * A default model stub that have all the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortByName(Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortByPhone(Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortByEmail(Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortByAddress(Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortByTag(Tag tag, Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasTag(Tag tag) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addTag(Tag tag) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void editTag(Tag oldTag, Tag newTag) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Tag> getTagList() {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that allows sorting.
+     */
+    private class ModelStubThatSorts extends ModelStub {
+        @Override
+        public void sortByName(Boolean isReverse) {}
+
+        @Override
+        public void sortByPhone(Boolean isReverse) {}
+
+        @Override
+        public void sortByEmail(Boolean isReverse) {}
+
+        @Override
+        public void sortByAddress(Boolean isReverse) {}
+
+        @Override
+        public void sortByTag(Tag tag, Boolean isReverse) {}
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -22,6 +23,8 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortArgument;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -60,6 +63,13 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        SortCommand command =
+            (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " " + PREFIX_NAME.getPrefix());
+        assertEquals(new SortCommand(List.of(new SortArgument(PREFIX_NAME, false, null))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static seedu.address.logic.parser.ArgumentTokenizer.PrefixArgument;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 
 public class ArgumentTokenizerTest {

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -13,7 +13,7 @@ import seedu.address.logic.commands.SortCommand.SortArgument;
 import seedu.address.model.tag.Tag;
 
 class SortCommandParserTest {
-    private String failureMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+    private final String failureMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
     private final SortCommandParser parser = new SortCommandParser();
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,11 +1,61 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortArgument;
+import seedu.address.model.tag.Tag;
+
 class SortCommandParserTest {
+    private String failureMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
+    private final SortCommandParser parser = new SortCommandParser();
 
     @Test
-    void parse() {
+    void parse_noValidArguments_failure() {
+        assertParseFailure(parser, "", failureMessage);
+        assertParseFailure(parser, "   ", failureMessage);
+        assertParseFailure(parser, "abcd", failureMessage);
+        assertParseFailure(parser, "an/namep/phone", failureMessage);
+    }
+
+    @Test
+    void parse_oneArgument_success() {
+        // test that the individual 1-level sorts function correctly
+
+        assertParseSuccess(parser, " n/",
+            new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null))));
+        assertParseSuccess(parser, " n/!",
+            new SortCommand(List.of(new SortArgument(new Prefix("n/"), true, null))));
+        assertParseSuccess(parser, " p/",
+            new SortCommand(List.of(new SortArgument(new Prefix("p/"), false, null))));
+        assertParseSuccess(parser, " p/!",
+            new SortCommand(List.of(new SortArgument(new Prefix("p/"), true, null))));
+        assertParseSuccess(parser, " e/",
+            new SortCommand(List.of(new SortArgument(new Prefix("e/"), false, null))));
+        assertParseSuccess(parser, " e/!",
+            new SortCommand(List.of(new SortArgument(new Prefix("e/"), true, null))));
+        assertParseSuccess(parser, " a/",
+            new SortCommand(List.of(new SortArgument(new Prefix("a/"), false, null))));
+        assertParseSuccess(parser, " a/!",
+            new SortCommand(List.of(new SortArgument(new Prefix("a/"), true, null))));
+        assertParseSuccess(parser, " t/friend",
+            new SortCommand(List.of(new SortArgument(new Prefix("t/"), false, new Tag("friend")))));
+        assertParseSuccess(parser, " t/!friend",
+            new SortCommand(List.of(new SortArgument(new Prefix("t/"), true, new Tag("friend")))));
+    }
+
+    @Test
+    void parse_multipleArgument_success() {
+        // test that 1-level sorts can be chained together in the correct order to form multi-level sort
+
+        assertParseSuccess(parser, " n/ a/!", new SortCommand(List.of(
+            new SortArgument(new Prefix("n/"), false, null),
+            new SortArgument(new Prefix("a/"), true, null))));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -29,25 +34,25 @@ class SortCommandParserTest {
         // test that the individual 1-level sorts function correctly
 
         assertParseSuccess(parser, " n/",
-            new SortCommand(List.of(new SortArgument(new Prefix("n/"), false, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_NAME, false, null))));
         assertParseSuccess(parser, " n/!",
-            new SortCommand(List.of(new SortArgument(new Prefix("n/"), true, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_NAME, true, null))));
         assertParseSuccess(parser, " p/",
-            new SortCommand(List.of(new SortArgument(new Prefix("p/"), false, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_PHONE, false, null))));
         assertParseSuccess(parser, " p/!",
-            new SortCommand(List.of(new SortArgument(new Prefix("p/"), true, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_PHONE, true, null))));
         assertParseSuccess(parser, " e/",
-            new SortCommand(List.of(new SortArgument(new Prefix("e/"), false, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_EMAIL, false, null))));
         assertParseSuccess(parser, " e/!",
-            new SortCommand(List.of(new SortArgument(new Prefix("e/"), true, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_EMAIL, true, null))));
         assertParseSuccess(parser, " a/",
-            new SortCommand(List.of(new SortArgument(new Prefix("a/"), false, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_ADDRESS, false, null))));
         assertParseSuccess(parser, " a/!",
-            new SortCommand(List.of(new SortArgument(new Prefix("a/"), true, null))));
+            new SortCommand(List.of(new SortArgument(PREFIX_ADDRESS, true, null))));
         assertParseSuccess(parser, " t/friend",
-            new SortCommand(List.of(new SortArgument(new Prefix("t/"), false, new Tag("friend")))));
+            new SortCommand(List.of(new SortArgument(PREFIX_TAG, false, new Tag("friend")))));
         assertParseSuccess(parser, " t/!friend",
-            new SortCommand(List.of(new SortArgument(new Prefix("t/"), true, new Tag("friend")))));
+            new SortCommand(List.of(new SortArgument(PREFIX_TAG, true, new Tag("friend")))));
     }
 
     @Test
@@ -55,7 +60,7 @@ class SortCommandParserTest {
         // test that 1-level sorts can be chained together in the correct order to form multi-level sort
 
         assertParseSuccess(parser, " n/ a/!", new SortCommand(List.of(
-            new SortArgument(new Prefix("n/"), false, null),
-            new SortArgument(new Prefix("a/"), true, null))));
+            new SortArgument(PREFIX_NAME, false, null),
+            new SortArgument(PREFIX_ADDRESS, true, null))));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class SortCommandParserTest {
+
+    @Test
+    void parse() {
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -2,11 +2,13 @@ package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -16,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 // import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
@@ -85,6 +88,80 @@ public class AddressBookTest {
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
+    }
+
+    @Test
+    void sortByName() {
+        AddressBook sampleA = new AddressBook();
+        AddressBook sampleB = new AddressBook();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByName(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByName(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByPhone() {
+        AddressBook sampleA = new AddressBook();
+        AddressBook sampleB = new AddressBook();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByPhone(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByPhone(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByEmail() {
+        AddressBook sampleA = new AddressBook();
+        AddressBook sampleB = new AddressBook();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByEmail(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByEmail(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByAddress() {
+        AddressBook sampleA = new AddressBook();
+        AddressBook sampleB = new AddressBook();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByAddress(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByAddress(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    /**
+     * Disabled until test methods has been updated for upgraded tags.
+     */
+    @Test
+    @Disabled
+    void sortByTag() {
+        AddressBook sampleA = new AddressBook();
+        AddressBook sampleB = new AddressBook();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByTag(new Tag("owesMoney"), true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByTag(new Tag("owesMoney"), false);
+        assertNotEquals(sampleA, sampleB);
     }
 
     /**

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -12,10 +13,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -128,5 +131,79 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+    }
+
+    @Test
+    void sortByName() {
+        ModelManager sampleA = new ModelManager();
+        ModelManager sampleB = new ModelManager();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByName(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByName(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByPhone() {
+        ModelManager sampleA = new ModelManager();
+        ModelManager sampleB = new ModelManager();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByPhone(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByPhone(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByEmail() {
+        ModelManager sampleA = new ModelManager();
+        ModelManager sampleB = new ModelManager();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByEmail(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByEmail(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByAddress() {
+        ModelManager sampleA = new ModelManager();
+        ModelManager sampleB = new ModelManager();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByAddress(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByAddress(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    /**
+     * Disabled until test methods has been updated for upgraded tags.
+     */
+    @Test
+    @Disabled
+    void sortByTag() {
+        ModelManager sampleA = new ModelManager();
+        ModelManager sampleB = new ModelManager();
+        sampleA.addPerson(ALICE);
+        sampleA.addPerson(BENSON);
+        sampleB.addPerson(BENSON);
+        sampleB.addPerson(ALICE);
+        sampleA.sortByTag(new Tag("owesMoney"), true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByTag(new Tag("owesMoney"), false);
+        assertNotEquals(sampleA, sampleB);
     }
 }

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -32,5 +33,17 @@ public class AddressTest {
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
+    }
+
+    @Test
+    void compareTo() {
+        Address a = new Address("alpha");
+        Address b = new Address("bravo");
+        Address c = new Address("charlie");
+        Address bb = new Address("BRAVO");
+
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, b.compareTo(c));
+        assertEquals(0, b.compareTo(bb)); // check that case is ignored in compareTo
     }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -64,5 +65,17 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+    }
+
+    @Test
+    void compareTo() {
+        Email a = new Email("alpha@xyz.com");
+        Email b = new Email("bravo@xyz.com");
+        Email c = new Email("charlie@xyz.com");
+        Email bb = new Email("BRAVO@xyz.com");
+
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, b.compareTo(c));
+        assertEquals(0, b.compareTo(bb)); // check that case is ignored in compareTo
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -36,5 +37,17 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+    }
+
+    @Test
+    void compareTo() {
+        Name a = new Name("A");
+        Name b = new Name("B");
+        Name c = new Name("C");
+        Name bb = new Name("b");
+
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, b.compareTo(c));
+        assertEquals(0, b.compareTo(bb)); // check that case is ignored in compareTo
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -36,5 +37,16 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+    }
+
+    @Test
+    void compareTo() {
+        Phone a = new Phone("10001234");
+        Phone b = new Phone("20001234");
+        Phone c = new Phone("30001234");
+
+        assertEquals(10000000, b.compareTo(a));
+        assertEquals(-10000000, b.compareTo(c));
+        assertEquals(0, b.compareTo(b)); // check that case is ignored in compareTo
     }
 }

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -240,9 +240,9 @@ public class UniquePersonListTest {
         sampleA.add(BENSON);
         sampleB.add(BENSON);
         sampleB.add(ALICE);
-        sampleA.sortByTag(new Tag("owesMoney"),true);
+        sampleA.sortByTag(new Tag("owesMoney"), true);
         assertEquals(sampleA, sampleB);
-        sampleA.sortByTag(new Tag("owesMoney"),false);
+        sampleA.sortByTag(new Tag("owesMoney"), false);
         assertNotEquals(sampleA, sampleB);
     }
 }

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -2,21 +2,25 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
@@ -166,5 +170,79 @@ public class UniquePersonListTest {
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, ()
             -> uniquePersonList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    void sortByName() {
+        UniquePersonList sampleA = new UniquePersonList();
+        UniquePersonList sampleB = new UniquePersonList();
+        sampleA.add(ALICE);
+        sampleA.add(BENSON);
+        sampleB.add(BENSON);
+        sampleB.add(ALICE);
+        sampleA.sortByName(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByName(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByPhone() {
+        UniquePersonList sampleA = new UniquePersonList();
+        UniquePersonList sampleB = new UniquePersonList();
+        sampleA.add(ALICE);
+        sampleA.add(BENSON);
+        sampleB.add(BENSON);
+        sampleB.add(ALICE);
+        sampleA.sortByPhone(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByPhone(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByEmail() {
+        UniquePersonList sampleA = new UniquePersonList();
+        UniquePersonList sampleB = new UniquePersonList();
+        sampleA.add(ALICE);
+        sampleA.add(BENSON);
+        sampleB.add(BENSON);
+        sampleB.add(ALICE);
+        sampleA.sortByEmail(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByEmail(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    @Test
+    void sortByAddress() {
+        UniquePersonList sampleA = new UniquePersonList();
+        UniquePersonList sampleB = new UniquePersonList();
+        sampleA.add(ALICE);
+        sampleA.add(BENSON);
+        sampleB.add(BENSON);
+        sampleB.add(ALICE);
+        sampleA.sortByAddress(true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByAddress(false);
+        assertNotEquals(sampleA, sampleB);
+    }
+
+    /**
+     * Disabled until test methods has been updated for upgraded tags.
+     */
+    @Test
+    @Disabled
+    void sortByTag() {
+        UniquePersonList sampleA = new UniquePersonList();
+        UniquePersonList sampleB = new UniquePersonList();
+        sampleA.add(ALICE);
+        sampleA.add(BENSON);
+        sampleB.add(BENSON);
+        sampleB.add(ALICE);
+        sampleA.sortByTag(new Tag("owesMoney"),true);
+        assertEquals(sampleA, sampleB);
+        sampleA.sortByTag(new Tag("owesMoney"),false);
+        assertNotEquals(sampleA, sampleB);
     }
 }


### PR DESCRIPTION
1. `sort t/TAG` now works (e.g. `sort t/friend`)
2. reverse sorting changed so that the `!` now comes after the prefix (e.g. `sort n/!`)
3. multi-sort now works (e.g. `sort t/friend n/!`)

For multi-sort, the first parameter will be used to sort the list. The second parameter will act as a tiebreaker for the first parameter, and so on.

This completes the Sorting Feature for v1.2.
- Implementation, JavaDocs, and Testing completed