### PR TITLE
Add autocomplete feature

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -465,7 +465,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **GUI**: A graphical user interface (GUI) is a form of user interface that allows users to interact with programs through graphical icons and audio indicator
 * **JavaFX**: A Java library used to develop client applications
 * **kLoC**: Stands for thousands of lines of code
-* **NUS**: National University of Singapore 
+* **NUS**: National University of Singapore
 * **SoC**: School of Computing, a computing school in NUS
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Autocomplete**: A feature that shows a list of completed words or strings without the user needing to type them in full

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.autocomplete.Autocomplete;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -47,4 +48,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the AutocompleteManager.
+     */
+    Autocomplete getAutocompleteManager();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.autocomplete.Autocomplete;
+import seedu.address.logic.autocomplete.AutocompleteManager;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -27,6 +29,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
+    private final Autocomplete autocomplete;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -35,6 +38,7 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
+        autocomplete = new AutocompleteManager(model.getUniqueNames());
     }
 
     @Override
@@ -47,6 +51,7 @@ public class LogicManager implements Logic {
 
         try {
             storage.saveAddressBook(model.getAddressBook());
+            autocomplete.updateUniqueNames(model.getUniqueNames());
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }
@@ -77,5 +82,10 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Autocomplete getAutocompleteManager() {
+        return this.autocomplete;
     }
 }

--- a/src/main/java/seedu/address/logic/autocomplete/Autocomplete.java
+++ b/src/main/java/seedu/address/logic/autocomplete/Autocomplete.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.autocomplete;
+
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * API of Autocomplete component.
+ */
+public interface Autocomplete {
+    /**
+     * Current autocomplete only supports the find command.
+     */
+    String AUTOCOMPLETE_COMMAND_WORD = "find ";
+
+    /**
+     * Updates the set of unique names whenever a command is executed.
+     *
+     * @param uniqueNames The updated set of unique names
+     */
+    void updateUniqueNames(TreeSet<String> uniqueNames);
+
+    /**
+     * Generates a list of autocomplete entries that starts with the given searchValue.
+     *
+     * @param searchValue The value to be matched with.
+     * @return A list of matching autocomplete entries.
+     */
+    List<String> getAutocompleteEntries(String searchValue);
+}

--- a/src/main/java/seedu/address/logic/autocomplete/AutocompleteManager.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutocompleteManager.java
@@ -6,6 +6,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
 import seedu.address.commons.core.LogsCenter;
 
 /**
@@ -27,8 +28,8 @@ public class AutocompleteManager implements Autocomplete {
 
     @Override
     public void updateUniqueNames(TreeSet<String> uniqueNames) {
-        logger.info("Updated unique list of names.");
         this.uniqueNames = uniqueNames;
+        logger.info("Updated unique list of names.");
     }
 
     @Override
@@ -41,5 +42,22 @@ public class AutocompleteManager implements Autocomplete {
         searchResult = uniqueNames.stream()
                 .filter(name -> name.toLowerCase().startsWith(lowerCaseSearchValue)).collect(Collectors.toList());
         return searchResult;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof AutocompleteManager)) {
+            return false;
+        }
+
+        // state check
+        AutocompleteManager other = (AutocompleteManager) obj;
+        return uniqueNames.equals(other.uniqueNames);
     }
 }

--- a/src/main/java/seedu/address/logic/autocomplete/AutocompleteManager.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutocompleteManager.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.autocomplete;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * Manager of the autocomplete component.
+ */
+public class AutocompleteManager implements Autocomplete {
+    private static final Logger logger = LogsCenter.getLogger(AutocompleteManager.class);
+
+    private SortedSet<String> uniqueNames;
+
+    /**
+     * Constructs a {@code AutocompleteManager} with the given uniqueNames.
+     *
+     * @param uniqueNames A set of unique names in the address book.
+     */
+    public AutocompleteManager(TreeSet<String> uniqueNames) {
+        this.uniqueNames = uniqueNames;
+    }
+
+    @Override
+    public void updateUniqueNames(TreeSet<String> uniqueNames) {
+        logger.info("Updated unique list of names.");
+        this.uniqueNames = uniqueNames;
+    }
+
+    @Override
+    public List<String> getAutocompleteEntries(String searchValue) {
+        List<String> searchResult = new LinkedList<>();
+        if (searchValue.length() == 0) {
+            return searchResult;
+        }
+        String lowerCaseSearchValue = searchValue.toLowerCase();
+        searchResult = uniqueNames.stream()
+                .filter(name -> name.toLowerCase().startsWith(lowerCaseSearchValue)).collect(Collectors.toList());
+        return searchResult;
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,11 +3,9 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 
 import javafx.collections.ObservableList;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.tag.Tag;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -74,6 +77,10 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void reverseSort() {
         persons.reverseSort();
+    }
+
+    public TreeSet<String> getUniqueNames() {
+        return persons.getUniqueNames();
     }
 
     //// person-level operations

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
 /**
@@ -100,6 +102,11 @@ public interface Model {
      * Sorts the address book in reverse order.
      */
     void reverseSort();
+
+    /**
+     * Returns a set of unique {@code Name} in the address book.
+     */
+    TreeSet<String> getUniqueNames();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,7 +6,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -134,6 +135,11 @@ public class ModelManager implements Model {
     @Override
     public void reverseSort() {
         addressBook.reverseSort();
+    }
+
+    @Override
+    public TreeSet<String> getUniqueNames() {
+        return addressBook.getUniqueNames();
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -5,6 +5,9 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -135,6 +138,17 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public void reverseSort() {
         FXCollections.reverse(internalList);
+    }
+
+    /**
+     * Returns a set of unique {@code Name} in the address book.
+     *
+     * @return a set of unique {@code Name}.
+     */
+    public TreeSet<String> getUniqueNames() {
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(internalList.stream().map(person -> person.getName().fullName).collect(Collectors.toList()));
+        return uniqueNames;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import java.util.LinkedList;
 import java.util.List;
+
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -72,9 +72,9 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Displays a list of autocomplete entries.
+     * Solution below adapted from https://stackoverflow.com/questions/36861056/javafx-textfield-auto-suggestions.
      */
     private void setAutocompleteListener() {
-        // Solution below adapted from https://stackoverflow.com/questions/36861056/javafx-textfield-auto-suggestions
         commandTextField.textProperty().addListener(new ChangeListener<String>() {
             @Override
             public void changed(ObservableValue<? extends String> observable, String oldValue, String newValue) {
@@ -103,11 +103,11 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Generates a list of autocomplete entries with the given search result.
+     * Solution below adapted from https://stackoverflow.com/questions/36861056/javafx-textfield-auto-suggestions.
      *
      * @param searchResult The list of matching strings
      */
     private void populatePopup(List<String> searchResult) {
-        // Solution below adapted from https://stackoverflow.com/questions/36861056/javafx-textfield-auto-suggestions
         List<CustomMenuItem> menuItems = new LinkedList<>();
         for (int i = 0; i < searchResult.size(); i++) {
             final String result = autocomplete.AUTOCOMPLETE_COMMAND_WORD + searchResult.get(i);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -119,7 +119,7 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, logic.getAutocompleteManager());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.ContextMenu?>
+<?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here...">
+      <contextMenu>
+         <ContextMenu fx:id="autocompletePopup">
+           <items>
+             <MenuItem mnemonicParsing="false" text="Unspecified Action" />
+           </items>
+         </ContextMenu>
+      </contextMenu></TextField>
 </StackPane>
-

--- a/src/test/java/seedu/address/logic/autocomplete/AutocompleteManagerTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutocompleteManagerTest.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.autocomplete;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.UniquePersonList;
+
+public class AutocompleteManagerTest {
+
+    private UniquePersonList uniquePersonList = new UniquePersonList();
+
+    private AutocompleteManager autocompleteManager = new AutocompleteManager(uniquePersonList.getUniqueNames());
+
+    @Test
+    public void updateUniqueNames_addedNewPerson_success() {
+        uniquePersonList.add(ALICE);
+        autocompleteManager.updateUniqueNames(uniquePersonList.getUniqueNames());
+        AutocompleteManager expectedAutocompleteManager = new AutocompleteManager(uniquePersonList.getUniqueNames());
+        assertEquals(expectedAutocompleteManager, autocompleteManager);
+    }
+
+    @Test
+    public void getAutocompleteEntries_withMatchingSearchValue_success() {
+        String searchValue = "A";
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(Arrays.asList("Alice", "Bob"));
+        autocompleteManager.updateUniqueNames(uniqueNames);
+        List<String> searchResult = autocompleteManager.getAutocompleteEntries(searchValue);
+        List<String> expectedSearchResult = Arrays.asList("Alice");
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void getAutocompleteEntries_withMultipleMatchingSearchValueInSortedOrder_success() {
+        String searchValue = "A";
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(Arrays.asList("Alice", "Alvin", "Alex", "Bob"));
+        autocompleteManager.updateUniqueNames(uniqueNames);
+        List<String> searchResult = autocompleteManager.getAutocompleteEntries(searchValue);
+        List<String> expectedSearchResult = Arrays.asList("Alex", "Alice", "Alvin");
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void getAutocompleteEntries_withCaseInsensitiveMatchingSearchValue_success() {
+        String searchValue = "AL";
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(Arrays.asList("Alice", "aLvin", "alex", "Bob"));
+        autocompleteManager.updateUniqueNames(uniqueNames);
+        List<String> searchResult = autocompleteManager.getAutocompleteEntries(searchValue);
+        List<String> expectedSearchResult = Arrays.asList("Alice", "aLvin", "alex");
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void getAutocompleteEntries_withNoMatchingSearchValue_success() {
+        String searchValue = "A";
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(Arrays.asList("Bob", "Carl"));
+        autocompleteManager.updateUniqueNames(uniqueNames);
+        List<String> searchResult = autocompleteManager.getAutocompleteEntries(searchValue);
+        List<String> expectedSearchResult = new ArrayList<>();
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void getAutocompleteEntries_withEmptySearchValue_success() {
+        String searchValue = "";
+        TreeSet<String> uniqueNames = new TreeSet<>();
+        uniqueNames.addAll(Arrays.asList("Bob", "Carl"));
+        autocompleteManager.updateUniqueNames(uniqueNames);
+        List<String> searchResult = autocompleteManager.getAutocompleteEntries(searchValue);
+        List<String> expectedSearchResult = new ArrayList<>();
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void equals() {
+        UniquePersonList uniquePersonList = new UniquePersonList();
+        uniquePersonList.add(ALICE);
+        TreeSet<String> uniqueNames = uniquePersonList.getUniqueNames();
+
+        // same uniqueNames -> returns true
+        autocompleteManager = new AutocompleteManager(uniqueNames);
+        AutocompleteManager autocompleteManagerCopy = new AutocompleteManager(uniqueNames);
+        assertTrue(autocompleteManager.equals(autocompleteManagerCopy));
+
+        // same object -> returns true
+        assertTrue(autocompleteManager.equals(autocompleteManager));
+
+        // null -> returns false
+        assertFalse(autocompleteManager.equals(null));
+
+        // different uniqueNames -> false
+        uniquePersonList.add(BOB);
+        TreeSet<String> differentUniqueNames = uniquePersonList.getUniqueNames();
+        assertFalse(autocompleteManager.equals(new AutocompleteManager(differentUniqueNames)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -161,6 +162,11 @@ public class AddCommandTest {
 
         @Override
         public void reverseSort() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public TreeSet<String> getUniqueNames() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -148,6 +149,11 @@ class SortCommandTest {
 
         @Override
         public void sortByTag(Tag tag, Boolean isReverse) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public TreeSet<String> getUniqueNames() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -166,5 +167,21 @@ public class UniquePersonListTest {
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, ()
             -> uniquePersonList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void getUniqueNames_listWithUniqueNames_success() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        TreeSet<String> listWithUniqueNames = uniquePersonList.getUniqueNames();
+        TreeSet<String> expectedListWithUniqueNames = new TreeSet<>();
+        expectedListWithUniqueNames.addAll(Arrays.asList(ALICE.getName().fullName, BOB.getName().fullName));
+        assertEquals(expectedListWithUniqueNames, listWithUniqueNames);
+    }
+
+    @Test
+    public void getUniqueNames_emptyList_success() {
+        TreeSet<String> expectedEmptyList = new TreeSet<>();
+        assertEquals(expectedEmptyList, uniquePersonList.getUniqueNames());
     }
 }


### PR DESCRIPTION
## Changes
- Added `AutocompleteManager` class to handle all autocomplete related tasks.
- `CommandBox` now also takes in `AutocompleteManager` as it requires `AutocompleteManager` to generate a list of possible autocomplete entries.
- Added `setAutocompleteListener` to `CommandBox` so it will generate a new list of autocomplete entries whenever there is a change in input in the `CommandBox`.

## Autocomplete
- Supports case insensitive search i.e. when the user types `a`, the word `Alice` will also be generated.
- Autocomplete entries will include the new names after new `Person` added.
- Only supports the `find` command for names and will have to change after the `search` for name and tag command is added.

<img width="823" alt="image" src="https://user-images.githubusercontent.com/56215606/193992857-a3901bd0-9f62-4b5b-a632-1cfcfb29461d.png">

## Known Issues
The size of the dropdown menu is dependent on the autocomplete entries - the height is dependent on the number of autocomplete entries and the width is dependent on the longest name in the autocomplete entries. Hence when the name is too long or the number of autocomplete entries generated is too many, it will cover the entire screen. I tried setting minimum and maximum height and width to the `contextMenu` but it seems like there is no effect, will have to look into this in the future.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/56215606/193993464-a09cf6e1-1950-4cd5-bdd2-43d3aea7c82f.png">
