### PR TITLE
Fix incorrect glossary format

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -470,6 +470,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **SoC**: School of Computing, a computing school in NUS
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Autocomplete**: A feature that shows a list of completed words or strings without the user needing to type them in full
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Appendix: Instructions for manual testing**


### PR DESCRIPTION
I am not really sure if this new white line solves the issue, but based on the old code, seems like there is a new line before the dotted line. Not tested yet, I think have to merge this and see whether it updates the github page.

![image](https://user-images.githubusercontent.com/56215606/194769798-725ef5de-6659-4650-923c-78752499f087.png)


The `DeveloperGuide.md` is working correctly, only the HTML page is rendered as `H2` tag.

From `DeveloperGuide.md`:
![image](https://user-images.githubusercontent.com/56215606/194769666-1684db2f-3ccf-4180-869b-86ae2c519dc8.png)

