### PR TITLE
Fix tag add bug where having no fields give an error

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,7 +33,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
-    public static final String MESSAGE_WRONG_TAG_COMMAND = "Tag cannot be added here. Please use the Tag Commands.";
+    public static final String MESSAGE_WRONG_TAG_COMMAND = "Please use Tag commands to add tags";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
-    public static final String MESSAGE_WRONG_TAG_COMMAND = "Please use Tag commands to edit tags.";
+    public static final String MESSAGE_WRONG_TAG_COMMAND = "Please use Tag commands to edit tags";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,9 +45,9 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
-    public static final String MESSAGE_WRONG_TAG_COMMAND = "Tag cannot be changed here. Please use the Tag Commands.";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_WRONG_TAG_COMMAND = "Please use Tag commands to edit tags.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/TagAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagAddCommand.java
@@ -40,7 +40,8 @@ public class TagAddCommand extends Command {
 
     public static final String MESSAGE_ADD_TAG_SUCCESS = "Tag added: %1$s";
     public static final String MESSAGE_NO_SUCH_TAG = "This tag does not exist";
-    public static final String MESSAGE_TAG_ALREADY_ADDED = "The contact already has the tag.";
+    public static final String MESSAGE_TAG_ALREADY_ADDED = "The contact already has the tag";
+    public static final String MESSAGE_NO_TAG = "Please specify a tag";
 
     private final Index index;
     private final Tag tag;

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -13,6 +13,6 @@ public class TagCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException, ParseException {
-        throw new ParseException("tag should not be stand alone.");
+        throw new ParseException("tag should not be stand alone");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TagEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagEditCommand.java
@@ -27,8 +27,8 @@ public class TagEditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Tag has changed from %1$s to %2$s";
     public static final String MESSAGE_NOT_EDITED = "Both tags need to be provided";
-    public static final String MESSAGE_DUPLICATE_TAG = "This new tag already exists.";
-    public static final String MESSAGE_TAG_NOT_FOUND = "This old tag does not exist.";
+    public static final String MESSAGE_DUPLICATE_TAG = "This new tag already exists";
+    public static final String MESSAGE_TAG_NOT_FOUND = "This old tag does not exist";
 
     private final Tag oldTag;
     private final Tag newTag;

--- a/src/main/java/seedu/address/logic/parser/TagAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagAddCommandParser.java
@@ -29,9 +29,14 @@ public class TagAddCommandParser implements Parser<TagAddCommand> {
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
-            tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagAddCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
+        } else {
+            throw new ParseException(TagAddCommand.MESSAGE_NO_TAG);
         }
 
         return new TagAddCommand(index, tag);

--- a/src/test/java/seedu/address/logic/parser/TagAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagAddCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.TagAddCommand.MESSAGE_NO_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -28,6 +29,9 @@ class TagAddCommandParserTest {
         // no index specified
         assertParseFailure(parser, TAG_DESC_FRIEND , MESSAGE_INVALID_FORMAT);
 
+        // no field specified
+        assertParseFailure(parser, "1", MESSAGE_NO_TAG);
+
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
@@ -45,6 +49,9 @@ class TagAddCommandParserTest {
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+
+        // missing tag
+        assertParseFailure(parser, "1", MESSAGE_NO_TAG);
     }
 
     @Test


### PR DESCRIPTION
Now catches error when there are no fields (ie `tag add 1`).

The error is now properly displayed.

JUnit test added.