### PR TITLE
Enable contact and attributes wrapping

### DIFF
--- a/src/main/java/soconnect/ui/PersonCard.java
+++ b/src/main/java/soconnect/ui/PersonCard.java
@@ -75,12 +75,12 @@ public class PersonCard extends UiPart<Region> {
         if (flowpanes[0] != null) {
             flowpanes[0].getChildren().add(new Label(person.getAddress().value));
             flowpanes[0].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA;"));
+                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
         }
         if (flowpanes[1] != null) {
             flowpanes[1].getChildren().add(new Label(person.getEmail().value));
             flowpanes[1].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA;"));
+                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
         }
         if (flowpanes[2] != null) {
             flowpanes[2].getChildren().add(new Label(person.getPhone().value));

--- a/src/main/java/soconnect/ui/PersonCard.java
+++ b/src/main/java/soconnect/ui/PersonCard.java
@@ -6,6 +6,7 @@ import static soconnect.logic.commands.customise.CustomiseCommand.NUMBER_OF_CUST
 
 import java.util.Comparator;
 
+import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
@@ -73,24 +74,34 @@ public class PersonCard extends UiPart<Region> {
         flowpanes[order[3]] = attributeD;
 
         if (flowpanes[0] != null) {
-            flowpanes[0].getChildren().add(new Label(person.getAddress().value));
-            flowpanes[0].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
+            flowpanes[0].maxWidthProperty().bind(Bindings.add(-100, cardPane.widthProperty()));
+            Label address = new Label(person.getAddress().value);
+            address.maxWidthProperty().bind(flowpanes[0].maxWidthProperty());
+            address.setStyle("-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; "
+                    + "-fx-wrap-text: true;");
+            flowpanes[0].getChildren().add(address);
         }
         if (flowpanes[1] != null) {
-            flowpanes[1].getChildren().add(new Label(person.getEmail().value));
-            flowpanes[1].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
+            flowpanes[1].maxWidthProperty().bind(Bindings.add(-100, cardPane.widthProperty()));
+            Label email = new Label(person.getEmail().value);
+            email.maxWidthProperty().bind(flowpanes[0].maxWidthProperty());
+            email.setStyle("-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; "
+                    + "-fx-wrap-text: true;");
+            flowpanes[1].getChildren().add(email);
         }
         if (flowpanes[2] != null) {
-            flowpanes[2].getChildren().add(new Label(person.getPhone().value));
-            flowpanes[2].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
+            flowpanes[2].maxWidthProperty().bind(Bindings.add(-100, cardPane.widthProperty()));
+            Label phone = new Label(person.getPhone().value);
+            phone.maxWidthProperty().bind(flowpanes[0].maxWidthProperty());
+            phone.setStyle("-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; "
+                    + "-fx-wrap-text: true;");
+            flowpanes[2].getChildren().add(phone);
         }
         if (flowpanes[3] != null) {
             person.getTags().stream()
                     .sorted(Comparator.comparing(tag -> tag.tagName))
                     .forEach(tag -> flowpanes[3].getChildren().add((new Label(tag.tagName))));
+            flowpanes[3].maxWidthProperty().bind(Bindings.add(-100, cardPane.widthProperty()));
             flowpanes[3].getChildren().forEach(label -> label.setStyle("-fx-background-color: #3142D3;"
                     + "-fx-font-size: 12; -fx-label-padding: 3 7 3 7; -fx-background-radius: 15;"
                     + "-fx-font-family: \"Karla\"; -fx-border-radius: 2;"

--- a/src/main/java/soconnect/ui/PersonCard.java
+++ b/src/main/java/soconnect/ui/PersonCard.java
@@ -85,7 +85,7 @@ public class PersonCard extends UiPart<Region> {
         if (flowpanes[2] != null) {
             flowpanes[2].getChildren().add(new Label(person.getPhone().value));
             flowpanes[2].getChildren().forEach(label -> label.setStyle(
-                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA;"));
+                    "-fx-font-size: 12;-fx-font-family: \"Karla\"; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
         }
         if (flowpanes[3] != null) {
             person.getTags().stream()
@@ -94,7 +94,7 @@ public class PersonCard extends UiPart<Region> {
             flowpanes[3].getChildren().forEach(label -> label.setStyle("-fx-background-color: #3142D3;"
                     + "-fx-font-size: 12; -fx-label-padding: 3 7 3 7; -fx-background-radius: 15;"
                     + "-fx-font-family: \"Karla\"; -fx-border-radius: 2;"
-                    + "-fx-padding: 1 3 1 3; -fx-text-fill: #FFDFEA;"));
+                    + "-fx-padding: 1 3 1 3; -fx-text-fill: #FFDFEA; -fx-wrap-text: true;"));
         }
     }
 

--- a/src/main/java/soconnect/ui/TodoCard.java
+++ b/src/main/java/soconnect/ui/TodoCard.java
@@ -3,6 +3,7 @@ package soconnect.ui;
 import java.util.Comparator;
 import java.util.Set;
 
+import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
@@ -70,10 +71,11 @@ public class TodoCard extends UiPart<Region> {
         newTag.stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> todoTags.getChildren().add(new Label(tag.tagName)));
+        todoTags.maxWidthProperty().bind(Bindings.add(-100, todoCardPane.widthProperty()));
         todoTags.getChildren().forEach(label -> label.setStyle("-fx-background-color: #9867C5;"
                 + "-fx-font-size: 12;-fx-background-radius: 15;-fx-font-family: \"Karla\";"
                 + "-fx-border-radius: 2;-fx-padding: 1 3 1 3; -fx-label-padding: 3 7 3 7;"
-                + "-fx-text-fill: #CAEFFF;"));
+                + "-fx-text-fill: #CAEFFF; -fx-wrap-text: true;"));
     }
 
     @Override

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -35,10 +35,10 @@
         </HBox>
         <VBox>
           <Label fx:id="name" styleClass="cell_big_label_person" text="\$first" />
-          <FlowPane fx:id="attributeA" />
-          <FlowPane fx:id="attributeB" />
-          <FlowPane fx:id="attributeC" />
-          <FlowPane fx:id="attributeD" />
+          <FlowPane fx:id="attributeA" styleClass="personAttribute" />
+          <FlowPane fx:id="attributeB" styleClass="personAttribute" />
+          <FlowPane fx:id="attributeC" styleClass="personAttribute" />
+          <FlowPane fx:id="attributeD" styleClass="personAttribute" />
         </VBox>
       </HBox>
     </VBox>

--- a/src/main/resources/view/SoConnectTheme.css
+++ b/src/main/resources/view/SoConnectTheme.css
@@ -233,6 +233,7 @@
     -fx-font-size: 22px;
     -fx-font-weight: 700;
     -fx-text-fill: #FFDFEA;
+    -fx-wrap-text: true;
 }
 
 #attributeA {
@@ -241,7 +242,7 @@
 }
 
 .personAttribute {
-    -fx-end-margin: 500;
+    -fx-wrap-text: true;
 }
 
 #attributeB {

--- a/src/main/resources/view/SoConnectTheme.css
+++ b/src/main/resources/view/SoConnectTheme.css
@@ -240,6 +240,10 @@
     -fx-vgap: 10;
 }
 
+.personAttribute {
+    -fx-end-margin: 500;
+}
+
 #attributeB {
     -fx-hgap: 10;
     -fx-vgap: 10;


### PR DESCRIPTION
Attributes now automatically resize.
<img width="254" alt="image" src="https://user-images.githubusercontent.com/76247368/199782779-5cfda6a4-9432-4783-9cb6-400408064b59.png">
<img width="253" alt="image" src="https://user-images.githubusercontent.com/76247368/199782820-99e92349-db07-4e37-80a9-ab9e86cc093f.png">

Action needed: @ChongCheeKaiClarence we don't need to limit any of the attributes, except for tag length. But I feel like phone size limit is still ok because of legal phone length is usually not that long.

Bug source:
It got to do with `FlowPane` characteristics. Unlike `Hbox`, `FlowPane` will wrap its children (good choice for tags), but will also let the children overflow if the width of child > width of `FlowPane` (bad choice for address etc.) . Therefore to fix this issue, we need to:
- set the `maxWidth` of `FlowPane` to be the same as the `maxWidth` of `CardPane`.
- set the `maxWidth` of the `Label` inside to be the same with `maxWidth` of `FlowPane`.
That way we force the child (`Label`) to never have width bigger than the parent (`FlowPane`).